### PR TITLE
wait for info before returning from connect

### DIFF
--- a/arduino-nats.h
+++ b/arduino-nats.h
@@ -21,6 +21,10 @@
 
 #define NATS_DEFAULT_PORT 4222
 
+#ifndef NATS_INFO_TIMEOUT
+#define NATS_INFO_TIMEOUT 1000
+#endif
+
 #ifndef NATS_PING_INTERVAL
 #define NATS_PING_INTERVAL 120000UL
 #endif
@@ -422,6 +426,13 @@ class NATS {
 			if (client->connect(hostname, port)) {
 				outstanding_pings = 0;
 				reconnect_attempts = 0;
+
+				unsigned long start = millis();
+				while(!connected || (millis() - start) >= NATS_INFO_TIMEOUT) {
+					process();
+					delay(10);
+				}
+
 				return true;
 			}
 			reconnect_attempts++;


### PR DESCRIPTION
Now that I finally had the time to try out the subscriptions I found out that because the connect returns before the INFO has been processed subscriptions don't get sent at all unless you call process at least once before subscribing. This PR makes the lib to wait for the INFO before returning from the connect function.

On arduino uno + ethernet the while loop is usually ran 2 or 3 times before the INFO has been received.
