### PR TITLE
Only call on_disconnect once per disconnection

### DIFF
--- a/ArduinoNATS.h
+++ b/ArduinoNATS.h
@@ -423,6 +423,7 @@ class NATS {
 		}
 
 		void disconnect() {
+			if (!connected) return;
 			connected = false;
 			client->stop();
 			subs.empty();


### PR DESCRIPTION
Previously on_disconnect was called every tick from NATS.process(). Patch returns early if NATS.connected has been previously set to false.