### PR TITLE
pass inbox subject to request()

### DIFF
--- a/ArduinoNATS.h
+++ b/ArduinoNATS.h
@@ -488,10 +488,9 @@ class NATS {
 			free_sids.push(sid);
 		}
 
-		int request(const char* subject, const char* msg, sub_cb cb, const int max_wanted = 1) {
+		int request(const char* subject, const char* inbox, const char* msg, sub_cb cb, const int max_wanted = 1) {
 			if (subject == NULL || subject[0] == 0) return -1;
 			if (!connected) return -1;
-			char* inbox = generate_inbox_subject();
 			int sid = subscribe(inbox, cb, NULL, max_wanted);
 			publish(subject, msg, inbox);
 			free(inbox);

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ class NATS {
 	int subscribe(const char* subject, sub_cb cb, const char* queue = NULL, const int max_wanted = 0);
 	void unsubscribe(const int sid);
 
-	int request(const char* subject, const char* msg, sub_cb cb, const int max_wanted = 1);
+	char* generate_inbox_subject();
+	int request(const char* subject, const char* inbox, const char* msg, sub_cb cb, const int max_wanted = 1);
 
 	void process();			// process pending messages from the buffer, must be called regularly in loop()
 }


### PR DESCRIPTION
If you use authentication on your NATS server, you can set access rights to topics; e.g. the user "alice" can only publish and subscribe to topics "alice.*", and the user "guest" can only subscribe to the topic "temperature".

But unless you've explicitly been granted access to subscribe to <random>, you're not going to be able to use request().

With this fix, the API changes so you have to do

```
char * topic = generate_inbox_subject();
ret = request("foo", topic, "help", callback); 
```

but, you can now also generate your own inbox subjects to fit your access rights on the server.